### PR TITLE
feat: implement temporal block repository with thread-safe storage

### DIFF
--- a/Repositories/TemporalBlockRepository.cs
+++ b/Repositories/TemporalBlockRepository.cs
@@ -16,6 +16,16 @@ public class TemporalBlockRepository : ITemporalBlockRepository
         return Task.FromResult(_temporalBlocks.TryAdd(temporalBlock.CountryCode, temporalBlock));
     }
 
+    public Task<bool> RemoveTemporalBlockAsync(string countryCode)
+    {
+        if (string.IsNullOrWhiteSpace(countryCode))
+            return Task.FromResult(false);
+
+        return Task.FromResult(_temporalBlocks.TryRemove(countryCode, out _));
+    }
+
+
+
 
 }
 

--- a/Repositories/TemporalBlockRepository.cs
+++ b/Repositories/TemporalBlockRepository.cs
@@ -1,0 +1,27 @@
+using System.Collections.Concurrent
+using CountryBlockingAPI.Interfaces;
+using CountryBlockingAPI.Models;
+
+namespace CountryBlockingAPI.Repositories;
+
+public class TemporalBlockRepository : ITemporalBlockRepository
+{
+    private readonly ConcurrentDictionary<string, TemporalBlock> _temporalBlocks = new(stringComparer.OrdinalIgnoreCase);
+
+    public Task<bool> AddTemporalBlockSync(TemporalBlock temporalBlock)
+    {
+        if (string.IsNullOrWhiteSpace(temporalBlock.CountryCode))
+            return Task.FromResult(false);
+        
+        return Task.FromResult(_temporalBlocks.TryAdd(temporalBlock.CountryCode, temporalBlock));
+    }
+
+
+}
+
+
+
+
+
+
+


### PR DESCRIPTION
…rrent dictionary (temp block repo with thread-safe)

validates against null inputs or empty spaces in country code which returns false and adds country as a value to the dict if the key 'country code is correct'