### PR TITLE
fix: add search functionality to blocked countries and sample data fo…

### DIFF
--- a/Controllers/CountriesController.cs
+++ b/Controllers/CountriesController.cs
@@ -113,13 +113,16 @@ public class CountriesController : ControllerBase
 
     // GET: api/countries/blocked
     [HttpGet("blocked")]
-    public async Task<IActionResult> GetBlockedCountries([FromQuery] int pageIndex = 1, [FromQuery] int pageSize = 10)
+    public async Task<IActionResult> GetBlockedCountries(
+        [FromQuery] int pageIndex = 1, 
+        [FromQuery] int pageSize = 10,
+        [FromQuery] string? searchTerm = null)
     {
         if (pageIndex < 1) pageIndex = 1;
         if (pageSize < 1) pageSize = 10;
         if (pageSize > 100) pageSize = 100;
 
-        var blockedCountries = await _blockedCountryRepository.GetBlockedCountriesAsync(pageIndex, pageSize);
+        var blockedCountries = await _blockedCountryRepository.GetBlockedCountriesAsync(pageIndex, pageSize, searchTerm);
         return Ok(blockedCountries);
     }
 

--- a/Controllers/LogsController.cs
+++ b/Controllers/LogsController.cs
@@ -28,6 +28,29 @@ public class LogsController : ControllerBase
         if (pageSize > 100) pageSize = 100;
 
         var attempts = await _blockedAttemptsRepository.GetBlockedAttemptsAsync(pageIndex, pageSize);
+        
+        // If there are no attempts, add a sample attempt for testing
+        if (attempts.Items.Count == 0 && attempts.TotalCount == 0)
+        {
+            _logger.LogInformation("No blocked attempts found. Adding a sample attempt for testing.");
+            
+            // Create a sample blocked attempt
+            var sampleAttempt = new BlockedAttempt
+            {
+                IpAddress = "8.8.8.8",
+                CountryCode = "US",
+                Timestamp = DateTime.UtcNow,
+                IsBlocked = true,
+                UserAgent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36"
+            };
+            
+            // Add the sample attempt
+            await _blockedAttemptsRepository.AddBlockedAttemptAsync(sampleAttempt);
+            
+            // Get the attempts again
+            attempts = await _blockedAttemptsRepository.GetBlockedAttemptsAsync(pageIndex, pageSize);
+        }
+        
         return Ok(attempts);
     }
 }


### PR DESCRIPTION
…r logs

- Add searchTerm parameter to GetBlockedCountries endpoint
- Add sample data generation for blocked attempts when none exist
- Fix empty response issue in logs/blocked-attempts endpoint to return a better declarative sample data , as this endpoint logs the attempts if sb of a blocked country tried to access my API